### PR TITLE
Alphaにデプロイするための設定を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PRIVATE_KEY = ""
+HANA_ALPHA_RPC_URL = ""

--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ REPORT_GAS=true npx hardhat test
 npx hardhat node
 npx hardhat run scripts/deploy.ts
 ```
+
+# Deploy to Hana Alpha Network
+
+```shell
+yarn install
+
+cp .env.example .env
+# edit .env to add RPC_URL & PRIVATE_KEY
+
+npx hardhat test
+npx hardhat run scripts/deploy.ts --network hanaAlpha
+```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,8 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: "0.8.20",
@@ -7,6 +10,12 @@ const config: HardhatUserConfig = {
     outDir: "typechain",
     target: "ethers-v5",
   },
+  networks: {
+    hanaAlpha: {
+      url: process.env.HANA_ALPHA_RPC_URL,
+      accounts: [process.env.PRIVATE_KEY],
+    }
+  }
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
+    "@typechain/ethers-v5": "^11.1.2",
     "@typechain/ethers-v6": "^0.5.0",
     "@typechain/hardhat": "^9.1.0",
     "@types/chai": "^4.2.0",
@@ -36,6 +37,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
-    "@openzeppelin/contracts-upgradeable": "^5.0.0"
+    "@openzeppelin/contracts-upgradeable": "^5.0.0",
+    "dotenv": "^16.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,14 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@typechain/ethers-v5@^11.1.2":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-11.1.2.tgz#82510c1744f37a2f906b9e0532ac18c0b74ffe69"
+  integrity sha512-ID6pqWkao54EuUQa0P5RgjvfA3MYqxUQKpbGKERbsjBW5Ra7EIXvbMlPp2pcP5IAdUkyMCFYsP2SN5q7mPdLDQ==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
 "@typechain/ethers-v6@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz#42fe214a19a8b687086c93189b301e2b878797ea"
@@ -1885,6 +1893,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"


### PR DESCRIPTION
## What's PR
.envファイルの環境変数だけ設定すれば、ネットワークのオプションを指定して簡単にAlphaネットワークに対してコントラクトをデプロイできるようにしました。ついでに、必要そうなパッケージも追加しておきました。

## Review checklist
- [ ] networkの設定ができているか

## その他
実際のネットワークの設定に必要なURLや秘密鍵は公開されない別の場所で共有します。


